### PR TITLE
persistent nock caching

### DIFF
--- a/rust/ares/src/interpreter.rs
+++ b/rust/ares/src/interpreter.rs
@@ -1334,28 +1334,6 @@ mod hint {
 
     /// Extracts a constant from a formula, skipping over
     /// safe/static hints, doing no computation.
-    /*
-u3_weak
-u3r_skip(u3_noun fol)
-{
-  while ( c3y == u3du(fol) ) {
-    switch ( u3h(fol) ) {
-      default: return u3_none;
-      case 1:  return u3t(fol);
-      case 11: {
-        u3_noun arg = u3t(fol),
-                hod = u3h(arg);
-
-        if ( (c3y == u3du(hod)) && (u3_none == u3r_skip(u3t(hod))) ) {
-          return u3_none;
-        }
-        fol = u3t(arg);
-      }
-    }
-  }
-  return u3_none;
-}
-     */
     pub fn skip(formula: Noun) -> Option<Noun> {
         let mut fol = formula;
         loop {
@@ -1376,8 +1354,7 @@ u3r_skip(u3_noun fol)
                     }
                     _ => return None,
                 }
-            }
-            else {
+            } else {
                 break None;
             }
         }
@@ -1586,10 +1563,10 @@ u3r_skip(u3_noun fol)
                 let mut key = Cell::new(stack, subject, body).as_noun();
                 if let Some(clue) = hint {
                     if clue.is_cell() {
-                        if unsafe { context.scry_stack.raw_equals(D(0)) } {
-                            eprintln!("serf: memoizing in keep\r");
-                            context.keep = keep.insert(stack, &mut key, res);
-                        }
+                        // if unsafe { context.scry_stack.raw_equals(D(0)) } {
+                        eprintln!("serf: memoizing in keep\r");
+                        context.keep = keep.insert(stack, &mut key, res);
+                        // }
                         // XX add a printf that says "userspace can't insert into
                         //    persistent cache"
                     } else {

--- a/rust/ares/src/interpreter.rs
+++ b/rust/ares/src/interpreter.rs
@@ -1334,11 +1334,35 @@ mod hint {
 
     /// Extracts a constant from a formula, skipping over
     /// safe/static hints, doing no computation.
+    /*
+u3_weak
+u3r_skip(u3_noun fol)
+{
+  while ( c3y == u3du(fol) ) {
+    switch ( u3h(fol) ) {
+      default: return u3_none;
+      case 1:  return u3t(fol);
+      case 11: {
+        u3_noun arg = u3t(fol),
+                hod = u3h(arg);
+
+        if ( (c3y == u3du(hod)) && (u3_none == u3r_skip(u3t(hod))) ) {
+          return u3_none;
+        }
+        fol = u3t(arg);
+      }
+    }
+  }
+  return u3_none;
+}
+     */
     pub fn skip(formula: Noun) -> Option<Noun> {
         let mut fol = formula;
         loop {
-            if let Ok(fol_cell) = fol.as_cell() {
-                match fol_cell.head().as_direct().unwrap().data() {
+            if fol.is_cell() {
+                let fol_cell = fol.as_cell().unwrap();
+                let op = fol_cell.head().as_direct().unwrap().data();
+                match op {
                     1 => return Some(fol_cell.tail()),
                     11 => {
                         let arg = fol_cell.tail().as_cell().unwrap();
@@ -1352,8 +1376,9 @@ mod hint {
                     }
                     _ => return None,
                 }
-            } else {
-                return None;
+            }
+            else {
+                break None;
             }
         }
     }

--- a/rust/ares/src/jets.rs
+++ b/rust/ares/src/jets.rs
@@ -319,6 +319,7 @@ pub mod util {
             let warm = Warm::new();
             let hot = Hot::init(&mut stack, URBIT_HOT_STATE);
             let cache = Hamt::<Noun>::new();
+            let keep = Hamt::<Noun>::new();
 
             Context {
                 stack,
@@ -327,6 +328,7 @@ pub mod util {
                 warm,
                 hot,
                 cache,
+                keep,
                 scry_stack: D(0),
                 trace_info: None,
             }

--- a/rust/ares/src/jets/nock.rs
+++ b/rust/ares/src/jets/nock.rs
@@ -150,6 +150,7 @@ pub mod util {
         let scry_snapshot = context.scry_stack;
 
         context.cache = Hamt::<Noun>::new();
+        context.keep = Hamt::<Noun>::new();
         context.scry_stack = T(&mut context.stack, &[scry, context.scry_stack]);
 
         match interpret(context, subject, formula) {

--- a/rust/ares/src/serf.rs
+++ b/rust/ares/src/serf.rs
@@ -61,6 +61,7 @@ impl Context {
             warm: Warm::new(),
             hot,
             cache: Hamt::<Noun>::new(),
+            keep: Hamt::<Noun>::new(),
             scry_stack: D(0),
             trace_info,
         };


### PR DESCRIPTION
Implements UIP-0103 for Ares. See https://github.com/urbit/vere/pull/508 for more. This PR depends on #143 to fix the "double jamming" problem, and also for an interface by which to implement cache reclamation/eviction for the persistent cache (`keep`).

Resolves #148.