### PR TITLE
disk: replay, epoch compatibility, and lmdb modules

### DIFF
--- a/rust/ares/Cargo.lock
+++ b/rust/ares/Cargo.lock
@@ -73,6 +73,8 @@ dependencies = [
  "json",
  "lazy_static",
  "libc",
+ "lmdb",
+ "lmdb-sys",
  "memmap",
  "murmur3",
  "num-derive",
@@ -676,6 +678,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
+name = "lmdb"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0908efb5d6496aa977d96f91413da2635a902e5e31dbef0bfb88986c248539"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "lmdb-sys",
+]
+
+[[package]]
+name = "lmdb-sys"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5b392838cfe8858e86fac37cf97a0e8c55cc60ba0a18365cadc33092f128ce9"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -761,6 +785,12 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "platforms"
@@ -945,18 +975,18 @@ checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
 
 [[package]]
 name = "serde"
-version = "1.0.196"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.196"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/ares/Cargo.toml
+++ b/rust/ares/Cargo.toml
@@ -34,6 +34,8 @@ num-derive = "0.3"
 num-traits = "0.2"
 signal-hook = "0.3"
 static_assertions = "1.1.0"
+lmdb = "0.8.0"
+lmdb-sys = "0.8.0"
 
 [build-dependencies]
 autotools = "0.2"

--- a/rust/ares/src/disk.rs
+++ b/rust/ares/src/disk.rs
@@ -1,0 +1,145 @@
+/** Disk storage for events. */
+use crate::jets::list::util::flop;
+use crate::lmdb::{lmdb_gulf, lmdb_read_meta};
+use crate::noun::{IndirectAtom, Noun, D, T};
+use crate::serf::Context;
+use crate::serialization::cue;
+use lmdb::{Cursor, Environment, Error as LmdbError, Transaction};
+use lmdb_sys as ffi;
+use std::convert::TryInto;
+use std::fs;
+use std::path::PathBuf;
+use std::result::Result as StdResult;
+
+#[derive(Debug, PartialEq)]
+pub enum Error {
+    InvalidPath,
+    EpochNotFound,
+    Lmdb(LmdbError),
+}
+
+pub type Result<T> = StdResult<T, Error>;
+
+pub struct Disk {
+    /// Full path to the pier's log directory.
+    pub dir: PathBuf,
+
+    /// Current epoch number.
+    pub epoch: u64,
+
+    /// Current epoch's LMDB environment.
+    pub env: Environment,
+
+    /// Last event number in the log.
+    pub done: u64,
+}
+
+impl Disk {
+    pub fn new(log_dir: PathBuf) -> Self {
+        let epoch = epoch_last(&log_dir).expect("Failed to get last epoch");
+        let epoch_dir = log_dir.join(format!("0i{}", epoch));
+        let mut env_builder = Environment::new();
+        env_builder.set_map_size(0x10000000000);
+        env_builder.set_max_dbs(2);
+        let env = env_builder
+            .open(epoch_dir.as_path())
+            .expect("Failed to open LMDB environment");
+        let (_, high) = lmdb_gulf(&env);
+        Disk {
+            dir: log_dir,
+            epoch: epoch,
+            env: env,
+            done: high,
+        }
+    }
+}
+
+/// Get the number of the latest epoch in the given directory, or return
+/// an error if there are no epochs or the path specified isn't a directory.
+pub fn epoch_last(log_dir: &PathBuf) -> Result<u64> {
+    if !log_dir.is_dir() {
+        return Err(Error::InvalidPath);
+    }
+
+    let mut some = false;
+    let mut last = 0;
+
+    if let Ok(entries) = fs::read_dir(log_dir.clone()) {
+        for entry in entries {
+            if let Ok(entry) = entry {
+                if let Some(name) = entry.file_name().to_str() {
+                    if let Some(epoch) = name.strip_prefix("0i") {
+                        if let Ok(n) = epoch.parse::<u64>() {
+                            some = true;
+                            if n > last {
+                                last = n;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if some {
+        return Ok(last);
+    }
+
+    Err(Error::EpochNotFound)
+}
+
+/// Read a value from the metadata database.
+pub fn disk_read_meta(env: &Environment, key: &str) -> Result<u64> {
+    lmdb_read_meta(env, key).map_err(|e| Error::Lmdb(e))
+}
+
+/// Read a single event `eve` from the database.
+pub fn disk_read_one(ctx: &mut Context, eve: u64) -> Option<Noun> {
+    let stack = &mut ctx.nock_context.stack;
+    let db_name = "EVENTS";
+    let log = &ctx.log;
+    let env = &log.env;
+    let txn = env.begin_ro_txn().unwrap();
+    let db = unsafe { txn.open_db(Some(db_name)).unwrap() };
+    let key = u64::to_le_bytes(eve);
+    if let Ok(value) = txn.get(db, &key) {
+        let mug_bytes = &value[0..4];
+        // XX use mug
+        let _mug = u32::from_ne_bytes(mug_bytes.try_into().unwrap());
+        let jam = unsafe { IndirectAtom::new_raw_bytes_ref(stack, &value[4..]) };
+        let e = cue(stack, jam.as_atom());
+        txn.abort();
+        Some(e)
+    } else {
+        txn.abort();
+        None
+    }
+}
+
+/// Read `len` events from the database, starting at `eve`.
+pub fn disk_read_list(ctx: &mut Context, eve: u64, len: u64) -> Option<Noun> {
+    let stack = &mut ctx.nock_context.stack;
+    let mut eves: Noun = D(0);
+    let db_name = "EVENTS";
+    let log = &ctx.log;
+    let env = &log.env;
+    let txn = env.begin_ro_txn().unwrap();
+    let db = unsafe { txn.open_db(Some(db_name)).unwrap() };
+    {
+        let cursor = txn.open_ro_cursor(db).unwrap();
+        let mut i = eve;
+        while i < eve + len {
+            let key = u64::to_le_bytes(i);
+            let value = cursor.get(Some(&key), None, ffi::MDB_SET_KEY).unwrap().1;
+            let mug_bytes = &value[0..4];
+            // XX use mug
+            let _mug = u32::from_ne_bytes(mug_bytes.try_into().unwrap());
+            let jam = unsafe { IndirectAtom::new_raw_bytes_ref(stack, &value[4..]) };
+            let e = cue(stack, jam.as_atom());
+            eves = T(stack, &[e, eves]);
+            i += 1;
+        }
+    }
+    txn.abort();
+    Some(flop(stack, eves).unwrap())
+}

--- a/rust/ares/src/disk.rs
+++ b/rust/ares/src/disk.rs
@@ -4,7 +4,7 @@ use crate::lmdb::{lmdb_gulf, lmdb_read_meta};
 use crate::noun::{IndirectAtom, Noun, D, T};
 use crate::serf::Context;
 use crate::serialization::cue;
-use lmdb::{Cursor, Environment, Error as LmdbError, Transaction};
+use lmdb::{Cursor, Environment, EnvironmentFlags, Error as LmdbError, Transaction};
 use lmdb_sys as ffi;
 use std::convert::TryInto;
 use std::fs;
@@ -41,6 +41,7 @@ impl Disk {
         let mut env_builder = Environment::new();
         env_builder.set_map_size(0x10000000000);
         env_builder.set_max_dbs(2);
+        env_builder.set_flags(EnvironmentFlags::NO_LOCK); // XX else linux hangs
         let env = env_builder
             .open(epoch_dir.as_path())
             .expect("Failed to open LMDB environment");

--- a/rust/ares/src/interpreter.rs
+++ b/rust/ares/src/interpreter.rs
@@ -428,7 +428,7 @@ pub fn interpret(context: &mut Context, mut subject: Noun, formula: Noun) -> Res
 
                             debug_assertions(stack, orig_subject);
                             debug_assertions(stack, res);
-
+                            
                             break Ok(res);
                         }
                         NockWork::Ret => {

--- a/rust/ares/src/interpreter.rs
+++ b/rust/ares/src/interpreter.rs
@@ -428,7 +428,7 @@ pub fn interpret(context: &mut Context, mut subject: Noun, formula: Noun) -> Res
 
                             debug_assertions(stack, orig_subject);
                             debug_assertions(stack, res);
-                            
+
                             break Ok(res);
                         }
                         NockWork::Ret => {

--- a/rust/ares/src/lib.rs
+++ b/rust/ares/src/lib.rs
@@ -3,11 +3,14 @@ extern crate num_derive;
 extern crate lazy_static;
 #[macro_use]
 extern crate static_assertions;
+pub mod disk;
 pub mod flog;
 pub mod guard;
 pub mod hamt;
 pub mod interpreter;
 pub mod jets;
+pub mod lmdb;
+pub mod mars;
 pub mod mem;
 pub mod mug;
 pub mod newt;

--- a/rust/ares/src/lmdb.rs
+++ b/rust/ares/src/lmdb.rs
@@ -28,7 +28,7 @@ pub fn lmdb_gulf(env: &Environment) -> (u64, u64) {
             let low = u64::from_le_bytes(first.try_into().unwrap());
             if let Some(last) = cursor.get(None, None, ffi::MDB_LAST).unwrap().0 {
                 let high = u64::from_le_bytes(last.try_into().unwrap());
-                return (low, high);
+                (low, high)
             } else {
                 panic!("Couldn't get last event from the database");
             }

--- a/rust/ares/src/lmdb.rs
+++ b/rust/ares/src/lmdb.rs
@@ -1,0 +1,41 @@
+use lmdb::{Cursor, Environment, Transaction};
+use lmdb_sys as ffi;
+use std::convert::TryInto;
+
+pub type Result<T> = std::result::Result<T, lmdb::Error>;
+
+pub fn lmdb_read_meta(env: &Environment, key: &str) -> Result<u64> {
+    let db_name = "META";
+    let txn = env.begin_ro_txn()?;
+    let db = unsafe { txn.open_db(Some(db_name))? };
+    let bytes: &[u8] = txn.get(db, &key.as_bytes())?;
+    if bytes.len() > 8 {
+        panic!("lmdb_read_meta: value too large for u64");
+    }
+    let mut value: u64 = 0;
+    for &byte in bytes.iter() {
+        value = (value << 8) | u64::from(byte);
+    }
+    Ok(value)
+}
+
+pub fn lmdb_gulf(env: &Environment) -> (u64, u64) {
+    let db_name = "EVENTS";
+    let txn = env.begin_ro_txn().unwrap();
+    if let Ok(db) = unsafe { txn.open_db(Some(db_name)) } {
+        let cursor = txn.open_ro_cursor(db).unwrap();
+        if let Some(first) = cursor.get(None, None, ffi::MDB_FIRST).unwrap().0 {
+            let low = u64::from_le_bytes(first.try_into().unwrap());
+            if let Some(last) = cursor.get(None, None, ffi::MDB_LAST).unwrap().0 {
+                let high = u64::from_le_bytes(last.try_into().unwrap());
+                return (low, high);
+            } else {
+                panic!("Couldn't get last event from the database");
+            }
+        } else {
+            panic!("Couldn't get first event from the database");
+        }
+    } else {
+        (0, 0)
+    }
+}

--- a/rust/ares/src/main.rs
+++ b/rust/ares/src/main.rs
@@ -1,7 +1,10 @@
 use ares::jets::hot::URBIT_HOT_STATE;
-use ares::serf::serf;
+use ares::mars::{mars_play, Mars};
+use ares::serf::{Context, serf};
+use ares::trace::{create_trace_file, write_metadata};
 use std::env;
 use std::io;
+use std::path::PathBuf;
 
 fn main() -> io::Result<()> {
     //  debug
@@ -13,9 +16,9 @@ fn main() -> io::Result<()> {
         };
     }
 
-    let filename = env::args().nth(1).expect("Must provide input filename");
+    let cmd = env::args().nth(1).expect("Must provide input filename");
 
-    if filename == "see gdb! definition in lib.rs about this" {
+    if cmd == "see gdb! definition in lib.rs about this" {
         ares::interpreter::use_gdb();
         ares::jets::use_gdb();
         ares::jets::bits::use_gdb();
@@ -31,9 +34,53 @@ fn main() -> io::Result<()> {
         ares::serialization::use_gdb();
     }
 
-    if filename == "serf" {
+    if cmd == "serf" {
         return serf(URBIT_HOT_STATE);
+    } else if cmd == "play" {
+        let pier_path = PathBuf::from(
+            env::args()
+                .nth(2)
+                .expect("Must provide path to log directory"),
+        );
+
+        let load_path = pier_path.clone();
+        let mut trace_info = create_trace_file(pier_path).ok();
+        if let Some(ref mut info) = trace_info.as_mut() {
+            if let Err(_e) = write_metadata(info) {
+                //  XX: need NockStack allocated string interpolation
+                //  XX: chicken/egg problem with flog bc it requires context
+                //      before we've initialized it, and context needs trace_info
+                // eprintln!("\rError initializing trace file: {:?}", e);
+                trace_info = None;
+            }
+        }
+        let mut ctx = Context::load(load_path.clone(), trace_info, URBIT_HOT_STATE);
+        ctx.ripe();
+        
+        let sent = ctx.event_num;
+        let done = sent;
+
+        let mars = Mars {
+            ctx: ctx,
+            dir: load_path,
+            sent: sent,
+            done: done,
+        };
+
+        let eve = env::args()
+            .nth(4)
+            .expect("Must provide event number to play up to")
+            .parse::<u64>()
+            .expect("Failed to parse event number");
+
+        let sap = env::args()
+            .nth(6)
+            .expect("Must provide snapshot interval")
+            .parse::<u64>()
+            .expect("Failed to parse snapshot interval");
+
+        mars_play(mars, eve, sap);
     }
 
-    panic!("Ares can only run as a serf!");
+    Ok(())
 }

--- a/rust/ares/src/main.rs
+++ b/rust/ares/src/main.rs
@@ -1,6 +1,6 @@
 use ares::jets::hot::URBIT_HOT_STATE;
 use ares::mars::{mars_play, Mars};
-use ares::serf::{Context, serf};
+use ares::serf::{serf, Context};
 use ares::trace::{create_trace_file, write_metadata};
 use std::env;
 use std::io;
@@ -56,7 +56,7 @@ fn main() -> io::Result<()> {
         }
         let mut ctx = Context::load(load_path.clone(), trace_info, URBIT_HOT_STATE);
         ctx.ripe();
-        
+
         let sent = ctx.event_num;
         let done = sent;
 

--- a/rust/ares/src/mars.rs
+++ b/rust/ares/src/mars.rs
@@ -1,12 +1,12 @@
-use std::{cmp::min, path::PathBuf};
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::result::Result as StdResult;
+use std::{cmp::min, path::PathBuf};
 
 use crate::disk::*;
 use crate::hamt::Hamt;
 use crate::jets::list::util::lent;
 use crate::lmdb::lmdb_gulf;
-use crate::noun::{D, Noun};
+use crate::noun::{Noun, D};
 use crate::persist::pma_close;
 use crate::serf::{clear_interrupt, play_life, work, Context};
 
@@ -45,13 +45,12 @@ pub struct Mars {
 
     /// Last event processed.
     pub done: u64,
-
 }
 
 /// Do a boot.
 fn mars_boot(mars: &mut Mars, eve: u64) -> Result<()> {
     let ctx = &mut mars.ctx;
-    let seq = disk_read_list(ctx, 1, eve).unwrap();  // boot sequence
+    let seq = disk_read_list(ctx, 1, eve).unwrap(); // boot sequence
     eprintln!("--------------- bootstrap starting ----------------\r");
     eprintln!("boot: 1-{}\r", lent(seq).unwrap());
     play_life(ctx, seq);
@@ -68,7 +67,10 @@ pub fn mars_play(mut mars: Mars, mut eve: u64, _sap: u64) -> u64 {
         eve = mars.ctx.log.done;
     } else if eve <= mars.ctx.log.done {
         eprintln!("mars: already computed {}\r", eve);
-        eprintln!("      state={}, &mut mars.log={}\r", mars.done, mars.ctx.log.done);
+        eprintln!(
+            "      state={}, &mut mars.log={}\r",
+            mars.done, mars.ctx.log.done
+        );
         return played;
     } else {
         eve = min(eve, mars.ctx.log.done);
@@ -96,14 +98,19 @@ pub fn mars_play(mut mars: Mars, mut eve: u64, _sap: u64) -> u64 {
     if (eve + 1) == mars.ctx.log.done {
         eprintln!("play: event {}\r", mars.ctx.log.done);
     } else if eve != mars.ctx.log.done {
-        eprintln!("play: events {}-{} of {}\r", (mars.done + 1), eve, mars.ctx.log.done);
+        eprintln!(
+            "play: events {}-{} of {}\r",
+            (mars.done + 1),
+            eve,
+            mars.ctx.log.done
+        );
     } else {
         eprintln!("play: events {}-{}\r", (mars.done + 1), eve);
     }
 
-    let mut _past = mars.done;  // XX last snapshot
-    let mut _meme = 0;          // XX last event to bail:meme
-    let mut _shot = 0;          // XX retry counter
+    let mut _past = mars.done; // XX last snapshot
+    let mut _meme = 0; // XX last event to bail:meme
+    let mut _shot = 0; // XX retry counter
 
     while mars.done < eve {
         match mars_play_batch(&mut mars, false, 1024) {
@@ -142,7 +149,7 @@ pub fn mars_play(mut mars: Mars, mut eve: u64, _sap: u64) -> u64 {
     played
 }
 
-/// Play a batch of events. 
+/// Play a batch of events.
 /// XX use `mug`, track time, and produce more errors.
 fn mars_play_batch(mars: &mut Mars, _mug: bool, bat: u64) -> Result<()> {
     let ctx = &mut mars.ctx;

--- a/rust/ares/src/mars.rs
+++ b/rust/ares/src/mars.rs
@@ -1,0 +1,171 @@
+use std::{cmp::min, path::PathBuf};
+use std::fmt::{Display, Formatter, Result as FmtResult};
+use std::result::Result as StdResult;
+
+use crate::disk::*;
+use crate::hamt::Hamt;
+use crate::jets::list::util::lent;
+use crate::lmdb::lmdb_gulf;
+use crate::noun::{D, Noun};
+use crate::persist::pma_close;
+use crate::serf::{clear_interrupt, play_life, work, Context};
+
+#[derive(Debug)]
+pub enum Error {
+    PlayOOM,
+    PlayInterrupted,
+    PlayEventLogFailure,
+    PlayMugMismatch,
+    PlayFailure,
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        match self {
+            Error::PlayOOM => write!(f, "play: out of memory"),
+            Error::PlayInterrupted => write!(f, "play: interrupted"),
+            Error::PlayEventLogFailure => write!(f, "play: event log failure"),
+            Error::PlayMugMismatch => write!(f, "play: mug mismatch"),
+            Error::PlayFailure => write!(f, "play: failure"),
+        }
+    }
+}
+
+pub type Result<T> = StdResult<T, Error>;
+
+pub struct Mars {
+    /// Serf context.
+    pub ctx: Context,
+
+    /// Execution directory (pier).
+    pub dir: PathBuf,
+
+    /// Last event requested.
+    pub sent: u64,
+
+    /// Last event processed.
+    pub done: u64,
+
+}
+
+/// Do a boot.
+fn mars_boot(mars: &mut Mars, eve: u64) -> Result<()> {
+    let ctx = &mut mars.ctx;
+    let seq = disk_read_list(ctx, 1, eve).unwrap();  // boot sequence
+    eprintln!("--------------- bootstrap starting ----------------\r");
+    eprintln!("boot: 1-{}\r", lent(seq).unwrap());
+    play_life(ctx, seq);
+    eprintln!("--------------- bootstrap complete ----------------\r");
+    Ok(())
+}
+
+/// Replay up to `eve`, snapshot every `sap` events.
+/// XX save every `sap` events, show time, produce more errors.
+pub fn mars_play(mut mars: Mars, mut eve: u64, _sap: u64) -> u64 {
+    let mut played = 0u64;
+
+    if eve == 0 {
+        eve = mars.ctx.log.done;
+    } else if eve <= mars.ctx.log.done {
+        eprintln!("mars: already computed {}\r", eve);
+        eprintln!("      state={}, &mut mars.log={}\r", mars.done, mars.ctx.log.done);
+        return played;
+    } else {
+        eve = min(eve, mars.ctx.log.done);
+    }
+
+    if mars.done == mars.ctx.log.done {
+        return played;
+    }
+
+    if mars.done < eve {
+        played = eve - mars.done;
+    }
+
+    if mars.done == 0 {
+        let life = disk_read_meta(&mars.ctx.log.env, "life").unwrap();
+
+        mars_boot(&mut mars, life).unwrap();
+
+        mars.sent = life;
+        mars.done = life;
+    }
+
+    eprintln!("---------------- playback starting ----------------\r");
+
+    if (eve + 1) == mars.ctx.log.done {
+        eprintln!("play: event {}\r", mars.ctx.log.done);
+    } else if eve != mars.ctx.log.done {
+        eprintln!("play: events {}-{} of {}\r", (mars.done + 1), eve, mars.ctx.log.done);
+    } else {
+        eprintln!("play: events {}-{}\r", (mars.done + 1), eve);
+    }
+
+    let mut _past = mars.done;  // XX last snapshot
+    let mut _meme = 0;          // XX last event to bail:meme
+    let mut _shot = 0;          // XX retry counter
+
+    while mars.done < eve {
+        match mars_play_batch(&mut mars, false, 1024) {
+            Ok(_) => {
+                // XX show the time
+                // XX only snapshot per `sap` events, not after each one
+                _past = mars.done;
+            }
+            Err(Error::PlayOOM) => {
+                eprintln!("play: out of memory\r");
+                break;
+            }
+            Err(Error::PlayInterrupted) => {
+                eprintln!("play: interrupted\r");
+                break;
+            }
+            Err(Error::PlayEventLogFailure) => {
+                eprintln!("play: event log failure\r");
+                break;
+            }
+            Err(Error::PlayMugMismatch) => {
+                eprintln!("play: mug mismatch\r");
+                break;
+            }
+            Err(Error::PlayFailure) => {
+                eprintln!("play: failure\r");
+                break;
+            }
+        }
+    }
+
+    let _ = pma_close();
+
+    eprintln!("---------------- playback complete ----------------\r");
+
+    played
+}
+
+/// Play a batch of events. 
+/// XX use `mug`, track time, and produce more errors.
+fn mars_play_batch(mars: &mut Mars, _mug: bool, bat: u64) -> Result<()> {
+    let ctx = &mut mars.ctx;
+    let (_, high) = lmdb_gulf(&ctx.log.env);
+    let mut i = mars.done + 1;
+    let start = i;
+    while i < (start + bat) && i <= high {
+        let e = disk_read_one(ctx, i);
+        match e {
+            Some(e) => {
+                let stack = &mut ctx.nock_context.stack;
+                ctx.nock_context.cache = Hamt::<Noun>::new(stack);
+                ctx.nock_context.scry_stack = D(0);
+                work(ctx, e);
+                mars.done = i;
+                clear_interrupt();
+                i += 1;
+            }
+            None => {
+                return Err(Error::PlayEventLogFailure);
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/rust/ares/src/serf.rs
+++ b/rust/ares/src/serf.rs
@@ -187,7 +187,7 @@ impl Context {
             arvo,
             mug,
             nock_context,
-            log
+            log,
         }
     }
 
@@ -319,7 +319,7 @@ pub fn serf(constant_hot_state: &[HotEntry]) -> io::Result<()> {
         .ok_or(io::Error::new(io::ErrorKind::Other, "no pier path"))?;
     let pier_path = PathBuf::from(pier_path_string);
     let snap_path = pier_path.join(".urb/chk");
-    create_dir_all(&snap_path)?;
+    create_dir_all(snap_path)?;
 
     let wag: u32 = std::env::args()
         .nth(4)


### PR DESCRIPTION
This PR adds bare bones replay functionality for `vere-v3.0`-style piers, meaning that one may: 
- Boot ships with the `vere-v3.0` king and Ares serf
- Restart ships which have been booted as above
- Perform a full replay of such a ship by deleting its `.urb/chk/data.pma` file

To achieve these results, very basic modules have been added for `lmdb`, `disk`, and `mars`. These are not well thought-out or designed-- instead, they are "minimum viable" and, as such, include numerous todo comments sprinkled throughout.

I have tested this PR on:
- [x] `macos-aarch64`
- [x] `linux-x86_64`
  - ~~For some reason, booting a fresh fake ship on this platform just hangs after `binary copy succeeded`~~

To fix functionality for `linux-x86_64`, we use `MDB_NOLOCK` (see `disk.rs:44`):
> Do not do any locking. If concurrent access is anticipated, the caller must manage all concurrency themself. For proper operation the caller must enforce single-writer semantics, and must ensure that no readers are using old transactions while a writer is active. The simplest approach is to use an exclusive lock so that no readers may be active at all when a writer begins.

Thus, we have two invariants to maintain:
- Only one writer is active at any given time.
  - We satisfy this because we never write from Rust (in fact, we don't even have any write functions implemented).
- No reader uses old transactions while a writer is active.
  - We satisfy this because we only read from the database during replay or when initializing the serf (our patterns mirror Vere's) and our read transactions are never active while a write transaction is also active.

Future work:
- Use mugs to verify replay correctness
- Achieve parity with Vere replay, including `play` arguments
- Use a real CLI parsing crate (or something along the lines that's better than our manual `argv` parsing)
- Handle IPC responses correctly, instead of printing garble
- Ensure safety against snapshot and/or event log corruption during replay
- Clean up code (Rust idioms, etc.)
- Look into why `serf: bail` is printed during boot and replay
- Think through and document proper designs for these systems when working on Ares "full Mars" implementation
- Implement replay tests for CI