### PR TITLE
fix hamt insert()

### DIFF
--- a/rust/sword/src/hamt.rs
+++ b/rust/sword/src/hamt.rs
@@ -421,7 +421,7 @@ impl<T: Copy + Preserve> Hamt<T> {
                             copy_nonoverlapping(stem.buffer, new_buffer, stem.size());
                             *new_buffer.add(idx) = Entry {
                                 leaf: Leaf {
-                                    len: leaf.len,
+                                    len: leaf.len + 1,
                                     buffer: new_leaf_buffer,
                                 },
                             };


### PR DESCRIPTION
I just compared with what the MutHamt does. It makes the HamtIterator test pass but I am still working on seeing if this breaks any NockApps.