### PR TITLE
interpreter: flop traces

### DIFF
--- a/rust/sword/src/interpreter.rs
+++ b/rust/sword/src/interpreter.rs
@@ -3,6 +3,7 @@ use crate::jets::cold::Cold;
 use crate::jets::hot::Hot;
 use crate::jets::warm::Warm;
 use crate::jets::{cold, JetErr};
+use crate::jets::list::util::flop;
 use crate::mem::{NockStack, Preserve};
 use crate::noun::{Atom, Cell, IndirectAtom, Noun, Slots, D, T};
 use crate::trace::{write_nock_trace, TraceInfo, TraceStack};
@@ -1201,7 +1202,8 @@ fn exit(
             Error::ScryBlocked(path) => path,
             Error::Deterministic(_, t) | Error::NonDeterministic(_, t) | Error::ScryCrashed(t) => {
                 // Return $tang of traces
-                let h = *(stack.local_noun_pointer(0));
+                let s = *(stack.local_noun_pointer(0));
+                let h = flop(stack, s).expect("serf: flop failed");
                 // XX: Small chance of clobbering something important after OOM?
                 // XX: what if we OOM while making a stack trace
                 T(stack, &[h, t])


### PR DESCRIPTION
Traces are inverted, and sometimes they force you to scroll up unnecessarily to figure out what went wrong.

**before**
```
2024-12-31T16:31:26.832404Z TRACE slogger: ------^
2024-12-31T16:31:26.832446Z TRACE slogger: ++  p arse-pile
2024-12-31T16:31:26.832450Z TRACE slogger: syntax error at [128 7] in /apps/choo/bootstrap/kernel.hoon   
2024-12-31T16:31:26.832455Z TRACE slogger: /apps/choo/bootstrap/kernel.hoon:<[136 3].[148 5]>
2024-12-31T16:31:26.832458Z TRACE slogger: /apps/choo/bootstrap/kernel.hoon:<[134 3].[148 5]>
2024-12-31T16:31:26.832461Z TRACE slogger: /apps/choo/bootstrap/kernel.hoon:<[131 3].[148 5]>
2024-12-31T16:31:26.832463Z TRACE slogger: /apps/choo/bootstrap/kernel.hoon:<[130 3].[148 5]>
2024-12-31T16:31:26.832466Z TRACE slogger: /apps/choo/bootstrap/kernel.hoon:<[360 27].[360 59]>
<...more here>
2024-12-31T16:31:26.832532Z TRACE slogger: /lib/wrapper.hoon:<[80 7].[88 54]>
2024-12-31T16:31:26.832534Z TRACE slogger: /lib/wrapper.hoon:<[79 7].[88 54]>
2024-12-31T16:31:26.832536Z TRACE slogger: /lib/wrapper.hoon:<[71 5].[89 7]>
2024-12-31T16:31:26.832538Z TRACE slogger: /lib/wrapper.hoon:<[70 5].[89 7]>

````
**after**
```
2024-12-31T16:27:52.929744Z TRACE slogger: /lib/wrapper.hoon:<[70 5].[89 7]>
2024-12-31T16:27:52.929785Z TRACE slogger: /lib/wrapper.hoon:<[71 5].[89 7]>
2024-12-31T16:27:52.929789Z TRACE slogger: /lib/wrapper.hoon:<[79 7].[88 54]>
2024-12-31T16:27:52.929792Z TRACE slogger: /lib/wrapper.hoon:<[80 7].[88 54]>
2024-12-31T16:27:52.929795Z TRACE slogger: /lib/wrapper.hoon:<[81 7].[88 54]>
<...more here>
2024-12-31T16:27:52.929858Z TRACE slogger: /apps/choo/bootstrap/kernel.hoon:<[360 3].[389 36]>
2024-12-31T16:27:52.929860Z TRACE slogger: /apps/choo/bootstrap/kernel.hoon:<[360 13].[360 64]>
2024-12-31T16:27:52.929862Z TRACE slogger: /apps/choo/bootstrap/kernel.hoon:<[360 27].[360 59]>
2024-12-31T16:27:52.929864Z TRACE slogger: /apps/choo/bootstrap/kernel.hoon:<[130 3].[148 5]>
2024-12-31T16:27:52.929867Z TRACE slogger: /apps/choo/bootstrap/kernel.hoon:<[131 3].[148 5]>
2024-12-31T16:27:52.929869Z TRACE slogger: /apps/choo/bootstrap/kernel.hoon:<[134 3].[148 5]>
2024-12-31T16:27:52.929871Z TRACE slogger: /apps/choo/bootstrap/kernel.hoon:<[136 3].[148 5]>
2024-12-31T16:27:52.929873Z TRACE slogger: syntax error at [128 7] in /apps/choo/bootstrap/kernel.hoon   
2024-12-31T16:27:52.929875Z TRACE slogger: ++  p arse-pile
2024-12-31T16:27:52.929876Z TRACE slogger: ------^
```