### PR TITLE
mook: flop works

### DIFF
--- a/rust/sword/src/jets/nock.rs
+++ b/rust/sword/src/jets/nock.rs
@@ -378,7 +378,9 @@ pub mod util {
                 list = cell.tail();
             }
 
-            *dest = D(0);
+            if !flop {
+                *dest = D(0);
+            }
             let toon = Cell::new(&mut context.stack, D(2), res);
             Ok(toon)
         }


### PR DESCRIPTION
Mook accepts a `flop` flag that allows you to reverse the stack traces (I don't know if this functionality is actually necessary anywhere), but currently, it always returns an empty list if the `flop` flag is set to true.